### PR TITLE
Correct directory errors

### DIFF
--- a/poc_scan/poc_patch_linux.py
+++ b/poc_scan/poc_patch_linux.py
@@ -142,7 +142,7 @@ def scan(args):
         print(f'[+] Generate {number.strip()} patchs: {patch_all_path}')
 
     executor = ProcessPoolExecutor(os.cpu_count()-1)
-    tasks = [executor.submit(compareThread, cve, patch_all_path) for cve in cves_path.joinpath(f'patch/{args.version}').glob('*')]
+    tasks = [executor.submit(compareThread, cve, patch_all_path) for cve in patch_sec_path.joinpath(f'{args.version}').glob('*')]
     executor.shutdown(True)
 
     results = defaultdict(dict)


### PR DESCRIPTION
目录变更之后，进行补丁对比时的cves_path路径忘记修改为patch_sec_patch